### PR TITLE
⚖️ balance

### DIFF
--- a/src/app/(main)/admin/playground/PlaygroundMatchView.tsx
+++ b/src/app/(main)/admin/playground/PlaygroundMatchView.tsx
@@ -49,7 +49,7 @@ export const PlaygroundMatchView = ({
     <MatchView
       match={match}
       forceParticipants={participants}
-      // calculateChangemakers
+      calculateChangemakers
     />
   )
 }

--- a/src/app/(main)/watch/items/page.tsx
+++ b/src/app/(main)/watch/items/page.tsx
@@ -2,7 +2,7 @@ import { getAllItems } from '@/game/allItems'
 import { LEADERBOARD_LIMIT } from '@/game/config'
 import { getLeaderboardRanked } from '@/game/getLeaderboard'
 import { capitalCase } from 'change-case'
-import { orderBy, sumBy } from 'lodash-es'
+import { orderBy, round, sumBy } from 'lodash-es'
 import { Metadata } from 'next'
 import { ItemChart } from './ItemChart'
 
@@ -32,6 +32,31 @@ export default async function Page() {
       entriesWithCount,
     }
   })
+
+  const itemsWithAttack = itemsRanked
+    .map((item) => {
+      const attacks = item.item.triggers?.flatMap((t) =>
+        t.type === 'interval' && t.attack ? t : [],
+      )
+      const damagePerSecond = round(
+        sumBy(attacks, (a) => (a.attack?.damage ?? 0) / (a.cooldown / 1000)),
+        2,
+      )
+      const staminaPerSecond = round(
+        sumBy(
+          attacks,
+          (a) => ((a.statsSelf?.stamina ?? 0) / (a.cooldown / 1000)) * -1,
+        ),
+        2,
+      )
+
+      return {
+        ...item,
+        damagePerSecond,
+        staminaPerSecond,
+      }
+    })
+    .filter((item) => item.damagePerSecond > 0)
 
   return (
     <>
@@ -125,6 +150,32 @@ export default async function Page() {
                 item.entriesWithCount,
                 (e) => e.count * item.item.price * (LEADERBOARD_LIMIT - e.rank),
               ),
+              fill: 'hsl(var(--chart-1))',
+            })),
+            (i) => i.value,
+            'desc',
+          )}
+        />
+        <ItemChart
+          title="Damage per second"
+          valueLabel="dps"
+          data={orderBy(
+            itemsWithAttack.map((item) => ({
+              name: capitalCase(item.item.name),
+              value: item.damagePerSecond,
+              fill: 'hsl(var(--chart-1))',
+            })),
+            (i) => i.value,
+            'desc',
+          )}
+        />
+        <ItemChart
+          title="Stamina per second"
+          valueLabel="stamina/s"
+          data={orderBy(
+            itemsWithAttack.map((item) => ({
+              name: capitalCase(item.item.name),
+              value: item.staminaPerSecond,
               fill: 'hsl(var(--chart-1))',
             })),
             (i) => i.value,

--- a/src/app/(main)/watch/items/page.tsx
+++ b/src/app/(main)/watch/items/page.tsx
@@ -163,7 +163,7 @@ export default async function Page() {
             itemsWithAttack.map((item) => ({
               name: capitalCase(item.item.name),
               value: item.damagePerSecond,
-              fill: 'hsl(var(--chart-1))',
+              fill: 'hsl(var(--chart-2))',
             })),
             (i) => i.value,
             'desc',
@@ -176,7 +176,7 @@ export default async function Page() {
             itemsWithAttack.map((item) => ({
               name: capitalCase(item.item.name),
               value: item.staminaPerSecond,
-              fill: 'hsl(var(--chart-1))',
+              fill: 'hsl(var(--chart-3))',
             })),
             (i) => i.value,
             'desc',

--- a/src/app/(main)/watch/leaderboard/page.tsx
+++ b/src/app/(main)/watch/leaderboard/page.tsx
@@ -15,13 +15,14 @@ import { calcLoadoutPrice } from '@/game/calcLoadoutPrice'
 import { LEADERBOARD_LIMIT } from '@/game/config'
 import { getLeaderboardRanked } from '@/game/getLeaderboard'
 import { getUserName } from '@/game/getUserName'
+import { revalidateLeaderboard } from '@/game/revalidateLeaderboard'
 import {
   streamDialog,
   streamToast,
   superAction,
 } from '@/super-action/action/createSuperAction'
-import { streamRevalidatePath } from '@/super-action/action/streamRevalidatePath'
 import { ActionButton } from '@/super-action/button/ActionButton'
+import { AutoActionClient } from '@/super-action/command/AutoActionClient'
 import { createStreamableUI } from 'ai/rsc'
 import { eq } from 'drizzle-orm'
 import { countBy, omitBy, orderBy, uniqBy } from 'lodash-es'
@@ -132,9 +133,14 @@ export default async function Page({
                           ui.done(
                             <>
                               <Progress value={100} />
+                              <AutoActionClient
+                                action={async () => {
+                                  'use server'
+                                  revalidateLeaderboard()
+                                }}
+                              />
                             </>,
                           )
-                          revalidatePath('/watch/leaderboard')
                         }
                       },
                     })
@@ -170,9 +176,14 @@ export default async function Page({
                       ui.done(
                         <>
                           <Progress value={100} />
+                          <AutoActionClient
+                            action={async () => {
+                              'use server'
+                              revalidateLeaderboard()
+                            }}
+                          />
                         </>,
                       )
-                      streamRevalidatePath('/watch/leaderboard')
                     }
                     streamDialog({
                       title: 'Leaderboard Updated',

--- a/src/components/game/ItemCard.tsx
+++ b/src/components/game/ItemCard.tsx
@@ -164,7 +164,7 @@ export const ItemCard = async (props: ItemCardProps) => {
           </div>
           {count >= 2 && (
             <>
-              <div className="absolute inset-0 flex flex-col items-center justify-center">
+              <div className="absolute inset-0 flex flex-col items-center justify-start py-16">
                 <div className="text-white rounded-full font-black px-8 py-2 text-6xl bg-black/80 -rotate-12 scale-150">
                   {count}x
                 </div>

--- a/src/components/game/ItemCard.tsx
+++ b/src/components/game/ItemCard.tsx
@@ -206,6 +206,7 @@ export const ItemCard = async (props: ItemCardProps) => {
                   relative
                   stats={item.stats}
                   disableTooltip={disableTooltip}
+                  canWrap
                 />
               )}
               {item.statsItem && (
@@ -216,6 +217,7 @@ export const ItemCard = async (props: ItemCardProps) => {
                     relative
                     stats={item.statsItem}
                     disableTooltip={disableTooltip}
+                    canWrap
                   />
                 </div>
               )}

--- a/src/components/game/MatchCardOverlay.tsx
+++ b/src/components/game/MatchCardOverlay.tsx
@@ -166,7 +166,7 @@ export const MatchCardOverlay = ({
       {stats && (
         <div
           className={cn(
-            'absolute inset-2 flex items-center justify-center scale-75 pointer-events-none',
+            'absolute inset-2 flex flex-col items-center justify-end origin-bottom scale-75 pointer-events-none',
             theme?.classBottom,
           )}
         >

--- a/src/game/addToLeaderboard.ts
+++ b/src/game/addToLeaderboard.ts
@@ -2,10 +2,10 @@ import { db } from '@/db/db'
 import { schema } from '@/db/schema-export'
 import { Loadout } from '@/db/schema-zod'
 import { and, eq } from 'drizzle-orm'
-import { revalidatePath } from 'next/cache'
 import { LEADERBOARD_TYPE } from './config'
 import { getLeaderboard } from './getLeaderboard'
 import { generateMatchByWorker } from './matchWorkerManager'
+import { revalidateLeaderboard } from './revalidateLeaderboard'
 import { seedToString } from './seed'
 
 export const addToLeaderboard = async ({
@@ -117,7 +117,7 @@ export const addToLeaderboard = async ({
     }
   }
 
-  revalidatePath('/watch/leaderboard')
+  revalidateLeaderboard()
 
   return {
     results,

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -1530,7 +1530,7 @@ const allItemsConst = [
         },
         statsSelf: {
           mana: -3,
-          barrier: 3,
+          barrier: 2,
         },
       },
     ],

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -217,6 +217,12 @@ const allItemsConst = [
       {
         type: 'interval',
         cooldown: 2_000,
+        statsRequired: {
+          stamina: 5,
+        },
+        statsSelf: {
+          stamina: -5,
+        },
         attack: {
           damage: 4,
           accuracy: 85,
@@ -245,6 +251,12 @@ const allItemsConst = [
       {
         type: 'interval',
         cooldown: 2_000,
+        statsRequired: {
+          stamina: 5,
+        },
+        statsSelf: {
+          stamina: -5,
+        },
         attack: {
           damage: 6,
           accuracy: 85,
@@ -508,7 +520,7 @@ const allItemsConst = [
         cooldown: 1_000,
         attack: {
           accuracy: 80,
-          damage: 2,
+          damage: 1,
         },
       },
       {
@@ -1532,7 +1544,13 @@ const allItemsConst = [
     triggers: [
       {
         type: 'interval',
-        cooldown: 2_000,
+        cooldown: 2_00,
+        statsRequired: {
+          stamina: 5,
+        },
+        statsSelf: {
+          stamina: -5,
+        },
         attack: {
           damage: 6,
           accuracy: 85,

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -318,7 +318,7 @@ const allItemsConst = [
     triggers: [
       {
         type: 'interval',
-        cooldown: 1_000,
+        cooldown: 1_500,
         statsSelf: {
           aim: 10,
         },
@@ -540,7 +540,7 @@ const allItemsConst = [
     shop: true,
     stats: {
       space: space(-2),
-      critDamage: 30,
+      critDamage: 15,
     },
   },
   {
@@ -1186,7 +1186,7 @@ const allItemsConst = [
         type: 'startOfBattle',
         statsSelf: {
           empower: 1,
-          haste: 15,
+          haste: 5,
         },
       },
     ],
@@ -1196,7 +1196,7 @@ const allItemsConst = [
     prompt: 'a long sword with a shiny metal blade',
     tags: ['weapon'],
     rarity: 'epic',
-    price: 3 + 4 + 4,
+    price: 3 + 4, // woodenSword + metalGloves
     shop: false,
     version: 2,
     stats: {
@@ -1221,7 +1221,7 @@ const allItemsConst = [
         type: 'startOfBattle',
         statsSelf: {
           empower: 2,
-          haste: 25,
+          haste: 20,
         },
       },
     ],

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -859,7 +859,7 @@ const allItemsConst = [
       {
         type: 'startOfBattle',
         statsSelf: {
-          thorns: 1,
+          thorns: 2,
         },
       },
     ],
@@ -869,7 +869,7 @@ const allItemsConst = [
     prompt: 'a bow and arrow made out of thorny wood',
     tags: ['weapon'],
     rarity: 'rare',
-    price: 8,
+    price: 4 + 4, // shortBow + roseBush
     shop: false,
     stats: {
       space: space(-2),

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -719,7 +719,7 @@ const allItemsConst = [
       {
         type: 'onAttackAfterHit',
         chancePercent: 30,
-        statsItem: {
+        statsSelf: {
           empower: 1,
         },
       },

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -213,9 +213,6 @@ const allItemsConst = [
     stats: {
       space: space(-2),
     },
-    statsItem: {
-      unblockable: 1,
-    },
     triggers: [
       {
         type: 'interval',
@@ -229,6 +226,7 @@ const allItemsConst = [
         type: 'onAttackCritAfterHit',
         statsItem: {
           critChance: 10,
+          unblockableChance: 10,
         },
       },
     ],
@@ -242,9 +240,6 @@ const allItemsConst = [
     shop: false,
     stats: {
       space: space(-2),
-    },
-    statsItem: {
-      unblockable: 1,
     },
     triggers: [
       {
@@ -260,6 +255,7 @@ const allItemsConst = [
         statsItem: {
           critChance: 10,
           haste: 10,
+          unblockableChance: 10,
         },
       },
     ],
@@ -1533,9 +1529,6 @@ const allItemsConst = [
     price: 3 + 7, // dagger + unstableManaCrystal
     shop: false,
     version: 2,
-    statsItem: {
-      unblockable: 1,
-    },
     triggers: [
       {
         type: 'interval',
@@ -1549,6 +1542,7 @@ const allItemsConst = [
         type: 'onAttackCritAfterHit',
         statsItem: {
           critChance: 10,
+          unblockableChance: 10,
         },
         statsSelf: {
           mana: 2,

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -191,6 +191,7 @@ const allItemsConst = [
     rarity: 'uncommon',
     price: 4,
     shop: true,
+    unique: true,
     stats: {
       space: space(-2),
     },
@@ -199,7 +200,7 @@ const allItemsConst = [
         type: 'startOfBattle',
         forceStartTime: 1, // force 1 tick later, else fest might not reach
         statsSelf: {
-          flying: 3,
+          flying: 5,
         },
       },
     ],
@@ -522,6 +523,18 @@ const allItemsConst = [
           accuracy: 80,
           damage: 1,
         },
+        modifiers: [
+          {
+            arithmetic: 'add',
+            targetStat: 'damage',
+            targetStats: 'attack',
+            valueAddingStats: ['flying'],
+            valueMultiplier: 5,
+            valueMax: 5,
+            sourceSide: 'enemy',
+            description: '**+5** *damage* if enemy has *flying*',
+          },
+        ],
       },
       {
         type: 'onAttackAfterHit',
@@ -1526,6 +1539,7 @@ const allItemsConst = [
     rarity: 'epic',
     price: 8,
     shop: true,
+    unique: true,
     version: 2,
     triggers: [
       {
@@ -1548,6 +1562,7 @@ const allItemsConst = [
     rarity: 'epic',
     price: 8,
     shop: true,
+    unique: true,
     version: 2,
     triggers: [
       {
@@ -1558,7 +1573,7 @@ const allItemsConst = [
         },
         statsSelf: {
           mana: -3,
-          barrier: 2,
+          block: 20,
         },
       },
     ],

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -181,7 +181,7 @@ const allItemsConst = [
     shop: true,
     stats: {
       space: space(-1),
-      lifeSteal: 20,
+      lifeSteal: 10,
     },
   },
   {
@@ -199,7 +199,7 @@ const allItemsConst = [
         type: 'startOfBattle',
         forceStartTime: 1, // force 1 tick later, else fest might not reach
         statsSelf: {
-          flying: 5,
+          flying: 3,
         },
       },
     ],
@@ -917,7 +917,7 @@ const allItemsConst = [
       {
         type: 'startOfBattle',
         statsSelf: {
-          luck: 5,
+          luck: 4,
         },
       },
     ],
@@ -1029,20 +1029,20 @@ const allItemsConst = [
       {
         type: 'interval',
         cooldown: 3_000,
+        statsSelf: {
+          randomDebuff: -1,
+        },
+      },
+      {
+        type: 'interval',
+        cooldown: 3_000,
         statsRequired: {
-          luck: 4,
+          luck: 5,
         },
         statsSelf: {
           empower: 1,
         },
         chancePercent: 50,
-      },
-      {
-        type: 'interval',
-        cooldown: 3_000,
-        statsSelf: {
-          randomDebuff: -1,
-        },
       },
     ],
   },

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -1104,6 +1104,7 @@ const allItemsConst = [
     rarity: 'common',
     price: 3,
     shop: true,
+    unique: true,
     version: 2,
     stats: {
       space: space(-3),

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -889,8 +889,8 @@ const allItemsConst = [
             targetStat: 'damage',
             targetStats: 'attack',
             valueAddingStats: ['thorns'],
-            description: '**+0.2** *damage* per *thorns*',
-            valueMultiplier: 0.2,
+            description: '**+0.5** *damage* per *thorns*',
+            valueMultiplier: 0.5,
           },
         ],
       },
@@ -899,7 +899,7 @@ const allItemsConst = [
         statsSelf: {
           thorns: 1,
         },
-        chancePercent: 50,
+        chancePercent: 70,
       },
     ],
   },
@@ -949,6 +949,16 @@ const allItemsConst = [
           damage: 5,
           accuracy: 100,
         },
+        modifiers: [
+          {
+            arithmetic: 'add',
+            targetStat: 'damage',
+            targetStats: 'attack',
+            valueAddingStats: ['luck'],
+            description: '**+0.2** *damage* per *luck*',
+            valueMultiplier: 0.2,
+          },
+        ],
       },
       {
         type: 'onAttackAfterHit',
@@ -986,12 +996,22 @@ const allItemsConst = [
           damage: 5,
           accuracy: 85,
         },
+        modifiers: [
+          {
+            arithmetic: 'add',
+            targetStat: 'damage',
+            targetStats: 'attack',
+            valueAddingStats: ['poison'],
+            sourceSide: 'enemy',
+            description: '**+0.5** *damage* per *poison* on enemy',
+            valueMultiplier: 0.5,
+          },
+        ],
       },
       {
         type: 'onAttackAfterHit',
         statsEnemy: {
           poison: 1,
-          randomDebuff: 1,
         },
         chancePercent: 70,
       },

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -1508,7 +1508,7 @@ const allItemsConst = [
         },
         statsSelf: {
           mana: -3,
-          flying: 3,
+          flying: 2,
         },
       },
     ],

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -557,10 +557,10 @@ const allItemsConst = [
         type: 'interval',
         cooldown: 1_500,
         statsRequired: {
-          stamina: 10,
+          stamina: 7,
         },
         statsSelf: {
-          stamina: -10,
+          stamina: -7,
         },
         statsEnemy: {
           blind: 3,

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -1574,7 +1574,7 @@ const allItemsConst = [
     triggers: [
       {
         type: 'interval',
-        cooldown: 2_00,
+        cooldown: 2_000,
         statsRequired: {
           stamina: 5,
         },

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -20,6 +20,8 @@ const allItemsConst = [
       stamina: 50,
       staminaMax: 50,
       staminaRegen: 10,
+      critChance: 10,
+      critDamage: 200,
       space: space(14),
     },
   },
@@ -213,14 +215,13 @@ const allItemsConst = [
     },
     statsItem: {
       unblockable: 1,
-      critChance: 30,
     },
     triggers: [
       {
         type: 'interval',
         cooldown: 2_000,
         attack: {
-          damage: 6,
+          damage: 4,
           accuracy: 85,
         },
       },
@@ -244,8 +245,6 @@ const allItemsConst = [
     },
     statsItem: {
       unblockable: 1,
-      critChance: 30,
-      haste: 30,
     },
     triggers: [
       {
@@ -1536,7 +1535,6 @@ const allItemsConst = [
     version: 2,
     statsItem: {
       unblockable: 1,
-      critChance: 30,
     },
     triggers: [
       {

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -662,6 +662,7 @@ const allItemsConst = [
     rarity: 'common',
     price: 4,
     shop: true,
+    unique: true,
     stats: {
       space: space(-2),
     },
@@ -670,10 +671,10 @@ const allItemsConst = [
         type: 'interval',
         cooldown: 2_200,
         statsRequired: {
-          stamina: 20,
+          stamina: 15,
         },
         statsSelf: {
-          stamina: -20,
+          stamina: -15,
         },
         attack: {
           damage: 8,
@@ -686,6 +687,13 @@ const allItemsConst = [
             targetStats: 'attack',
             valueAddingTags: ['food'],
             description: '**+1** *damage* per *food*',
+          },
+          {
+            arithmetic: 'add',
+            targetStat: 'haste',
+            targetStats: 'statsForItem',
+            valueAddingStats: ['hungry'],
+            description: '**+1** *haste* per *hungry*',
           },
         ],
       },

--- a/src/game/allItems.ts
+++ b/src/game/allItems.ts
@@ -1124,6 +1124,7 @@ const allItemsConst = [
     rarity: 'rare',
     price: 5,
     shop: true,
+    unique: true,
     triggers: [
       {
         type: 'startOfBattle',
@@ -1132,9 +1133,9 @@ const allItemsConst = [
             arithmetic: 'add',
             targetStats: 'statsSelf',
             targetStat: 'hungry',
-            description: 'Get **+1.5** *hungry* for every *food*',
+            description: 'Get **+10** *hungry* for every *food*',
             valueAddingTags: ['food'],
-            valueMultiplier: 1.5,
+            valueMultiplier: 10,
           },
         ],
       },

--- a/src/game/config.ts
+++ b/src/game/config.ts
@@ -20,7 +20,6 @@ export const IGNORE_SPACE = true
 export const MATCH_CARD_ANIMATION_DURATION = 1_000
 
 export const MAX_THORNS_MULTIPLIER = 1.5
-export const CRIT_MULTIPLIER = 2
 
 export const WORKER_COUNT = 8
 export const WORKER_MAX_LISTENERS = 100

--- a/src/game/craftingRecipes.ts
+++ b/src/game/craftingRecipes.ts
@@ -76,7 +76,7 @@ export const craftingRecipes: CraftingRecipe[] = [
   {
     input: [
       { name: 'woodenSword', count: 1 },
-      { name: 'metalGloves', count: 2 },
+      { name: 'metalGloves', count: 1 },
     ],
     output: [{ name: 'longSword' }],
     version: 2,

--- a/src/game/generateMatch.ts
+++ b/src/game/generateMatch.ts
@@ -23,7 +23,7 @@ import {
   MAX_THORNS_MULTIPLIER,
 } from './config'
 import { TriggerEventType } from './ItemDefinition'
-import { getAllModifiedStats } from './modifiers'
+import { getAllModifiedStats, getModifiedStats } from './modifiers'
 import { orderItems } from './orderItems'
 import { randomStatsResolve } from './randomStatsResolve'
 import { Stats } from './stats'
@@ -686,6 +686,7 @@ export const generateMatch = async ({
     }
 
     // UPDATE COOLDOWN
+    // TODO: merge this with the cooldown set at start
     for (const action of futureActions) {
       if (action.time !== time) continue
       if (action.type !== 'baseTick') {
@@ -695,9 +696,22 @@ export const generateMatch = async ({
         if (trigger.type === 'startOfBattle') {
           action.time = MAX_MATCH_TIME // TODO: find a more elegant solution
         } else if (trigger.type === 'interval') {
-          const statsForItem = item.statsItem
+          let statsForItem = item.statsItem
             ? sumStats2(side.stats, item.statsItem)
             : side.stats
+          const modifiedStatsForItem = getModifiedStats(
+            {
+              state,
+              sideIdx: action.sideIdx,
+              itemIdx: action.itemIdx,
+              triggerIdx: action.triggerIdx,
+              statsForItem,
+            },
+            'statsForItem',
+          )
+          if (modifiedStatsForItem) {
+            statsForItem = modifiedStatsForItem
+          }
           const cooldown = calcCooldown({
             cooldown: trigger.cooldown,
             stats: statsForItem,

--- a/src/game/generateMatch.ts
+++ b/src/game/generateMatch.ts
@@ -62,7 +62,7 @@ const generateMatchStateSides = async (input: GenerateMatchInput) => {
           return {
             ...def,
             statsItem: def.statsItem ? { ...def.statsItem } : undefined,
-            count: i.count ?? 1,
+            count: def.unique ? 1 : (i.count ?? 1),
           }
         }),
       )

--- a/src/game/generateMatch.ts
+++ b/src/game/generateMatch.ts
@@ -487,7 +487,12 @@ export const generateMatch = async ({
               damage = Math.round(damage)
 
               let blockedDamage = 0
-              if (!statsForItem?.unblockable) {
+              let unblockable = false
+              if (statsForItem?.unblockableChance) {
+                unblockable =
+                  rngFloat({ seed, max: 100 }) <= statsForItem.unblockableChance
+              }
+              if (!unblockable) {
                 blockedDamage = Math.min(damage, otherSide.stats.block ?? 0)
               }
               damage -= blockedDamage

--- a/src/game/generateMatch.ts
+++ b/src/game/generateMatch.ts
@@ -18,7 +18,6 @@ import {
 } from './calcStats'
 import {
   BASE_TICK_TIME,
-  CRIT_MULTIPLIER,
   FATIGUE_STARTS_AT,
   MAX_MATCH_TIME,
   MAX_THORNS_MULTIPLIER,
@@ -481,7 +480,6 @@ export const generateMatch = async ({
               }
 
               if (doesCrit) {
-                damage *= CRIT_MULTIPLIER
                 if (statsForItem?.critDamage) {
                   damage *= 1 + statsForItem.critDamage / 100
                 }

--- a/src/game/modifiers.ts
+++ b/src/game/modifiers.ts
@@ -37,7 +37,7 @@ export const Modifier = z.object({
 })
 export type Modifier = z.infer<typeof Modifier>
 
-const getModifiedStats = (
+export const getModifiedStats = (
   {
     state,
     sideIdx,

--- a/src/game/revalidateLeaderboard.ts
+++ b/src/game/revalidateLeaderboard.ts
@@ -1,0 +1,6 @@
+import { revalidatePath } from 'next/cache'
+
+export const revalidateLeaderboard = () => {
+  revalidatePath('/watch/leaderboard')
+  revalidatePath('/watch/items')
+}

--- a/src/game/stats.ts
+++ b/src/game/stats.ts
@@ -196,11 +196,10 @@ const heroStats = [
     tooltip: 'Increases accuracy by X%.',
   },
   {
-    name: 'unblockable',
+    name: 'unblockableChance',
     icon: ShieldOff,
     bgClass: 'bg-cyan-500',
-    tooltip: 'Cannot be blocked.',
-    hideCount: true,
+    tooltip: 'X% chance to ignore block.',
   },
   {
     name: 'critChance',


### PR DESCRIPTION
# Auto Cards - Balance Patch

We are excited to bring you the latest update to **Auto Cards**! This patch includes balance changes to enhance your gameplay experience.

---

### **Critical Mechanics Revisted**

- **Critical Chance** and **Critical Damage** mechanics have been added to the game.
  - **Hero** now starts with:
    - **Critical Chance**: 10%
    - **Critical Damage**: 200%

---

## **Item Changes**

### **General Adjustments**

- **Stamina Costs**: Many weapons now require stamina to use, adding a strategic layer to combat.
- **Unique Items**: Certain items are now unique, meaning only one can be held at a time.
- **Balance Tweaks**: Stats and abilities have been adjusted across multiple items for better game balance.

---

### **Item-Specific Changes**

#### **Hero**

- Added **Critical Chance**: 10%
- Added **Critical Damage**: 200%

#### **Syringe**

- **Life Steal** reduced from **20** to **10**.

#### **Balloon**

- **Unique Item**: Only one can be equipped at a time.

#### **Dagger**

- **Damage** reduced from **6** to **4**.
- **Stamina Requirement** added:
  - Requires **5 Stamina** to attack.
  - Consumes **5 Stamina** per attack.
- **Unblockable Chance** added on critical hits: Increases **Unblockable Chance** by **10%**.

#### **Fire Dagger**

- **Stamina Requirement** added:
  - Requires **5 Stamina** to attack.
  - Consumes **5 Stamina** per attack.
- On critical hits, increases:
  - **Critical Chance** by **10%**.
  - **Haste** by **10%**.
  - **Unblockable Chance** by **10%**.

#### **Spyglass**

- **Cooldown** increased from **1,000ms** to **1,500ms**.

#### **Darts**
- **Damage** reduced from **2** to **1**
- **+5** *damage* if enemy has *flying*.

#### **Whetstone**

- **Critical Damage** bonus reduced from **30%** to **15%**.

#### **Thorns Whip**

- Chance to gain **Thorns** on attack increased from **50%** to **100%**.

#### **Pan**

- **Unique Item**: Only one can be equipped at a time.
- **Stamina Cost** increased from **10** to **15** per attack.
- Added Modifier:
  - Gains **+1 Haste** per **Hungry** status effect.

#### **Mixer**

- **Unique Item**: Only one can be equipped at a time.
- **Hungry** status effect per **Food** increased from **1.5** to **10**.

#### **Metal Gloves**

- **Haste** bonus reduced from **15%** to **5%**.

#### **Thorn Bow**

- **Damage Modifier** per **Thorns** increased from **+0.2** to **+0.5**.
- Chance to gain **Thorns** on attack increased from **50%** to **70%**.

#### **Lucky Clover**

- **Luck** bonus reduced from **5** to **4**.

#### **Lucky Bow**

- Added **Damage Modifier**: Gains **+0.2 Damage** per **Luck**.

#### **Poison Bow**

- Added **Damage Modifier**: Gains **+0.5 Damage** per **Poison** on the enemy.
- Clarified that the modifier sources **Poison** from the enemy.

#### **Carrot**

- **Luck Requirement** increased from **4** to **5** to gain **Empower**.
- Now removes **1 Random Debuff** every **3 seconds**.
- **Empower** chance remains at **50%**.

#### **Piggy Bank**

- **Unique Item**: Only one can be equipped at a time.

#### **HorseShoe**

- No significant changes to stats or abilities.


#### **Mana Wings**

- **Unique Item**: Only one can be equipped at a time.
- **Flying** bonus reduced from **+3** to **+2** per activation.

#### **Mana Barrier**

- **Unique Item**: Only one can be equipped at a time.
- Does not give **Barrier** anymore.
- Gives **20 Block** now per activation

#### **Mana Dagger**

- **Stamina Requirement** added:
  - Requires **5 Stamina** to attack.
  - Consumes **5 Stamina** per attack.
- On critical hits, now also increases:
  - **Unblockable Chance** by **10%**.